### PR TITLE
flake: update cardano-node to 1.35.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "CHaP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668591548,
+        "narHash": "sha256-8OaFZJ3tKxFSxbxamf30c95u2OcpP+4FXCaSNiB3kbU=",
+        "owner": "input-output-hk",
+        "repo": "cardano-haskell-packages",
+        "rev": "487cc8ceb9c4ea7f6a6ecde65e43da770d12bc92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "repo",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
+      }
+    },
     "HTTP": {
       "flake": false,
       "locked": {
@@ -1157,6 +1174,7 @@
     },
     "cardano-node": {
       "inputs": {
+        "CHaP": "CHaP",
         "cardano-mainnet-mirror": "cardano-mainnet-mirror",
         "cardano-node-workbench": [
           "cardano-node-workbench"
@@ -1185,16 +1203,16 @@
         "utils": "utils_4"
       },
       "locked": {
-        "lastModified": 1659625017,
-        "narHash": "sha256-4IrheFeoWfvkZQndEk4fGUkOiOjcVhcyXZ6IqmvkDgg=",
+        "lastModified": 1667644902,
+        "narHash": "sha256-WRRzfpDc+YVmTNbN9LNYY4dS8o21p/6NoKxtcZmoAcg=",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "950c4e222086fed5ca53564e642434ce9307b0b9",
+        "rev": "ebc7be471b30e5931b35f9bbc236d21c375b91bb",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "1.35.3",
+        "ref": "1.35.4",
         "repo": "cardano-node",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     # Use divnix/blank to fix CI failing due to broken cardano-node flake
     cardano-node = {
-      url = "github:input-output-hk/cardano-node?ref=1.35.3";
+      url = "github:input-output-hk/cardano-node?ref=1.35.4";
       inputs.cardano-node-workbench.follows = "cardano-node-workbench";
       inputs.node-measured.follows = "cardano-node-workbench";
     };


### PR DESCRIPTION
Closes

other changes

- [ ] The impure tests via `nix run .#offchain:test` were run and all are passing.
- [ ] Where applicable, grammar, punctuation, and spelling within code and comments should be plausibly correct.
- [ ] The issue(s) that the work is addressing should be linked in the PR description.
- [ ] Any significant changes beyond what's clear from the linked issue(s) are documented in the PR description

