### PR TITLE
flake/ctl: fix non-existing revision error due to ctl history rewrite

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1628,16 +1628,16 @@
       },
       "locked": {
         "lastModified": 1664916044,
-        "narHash": "sha256-02aYFdkV6L2BgmW9J7YOdZS/lEf9198WvSH9+z10mCs=",
+        "narHash": "sha256-MpH7D1bbd/9SKEaEOleArtMIoQQfhOyaBmKBN3pYrZc=",
         "owner": "Plutonomicon",
         "repo": "cardano-transaction-lib",
-        "rev": "1999bb962141ffea09767f299a5759420097d189",
+        "rev": "67ae3d1a3e7128cb7f58a5b4ba365aae37133045",
         "type": "github"
       },
       "original": {
         "owner": "Plutonomicon",
         "repo": "cardano-transaction-lib",
-        "rev": "1999bb962141ffea09767f299a5759420097d189",
+        "rev": "67ae3d1a3e7128cb7f58a5b4ba365aae37133045",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       inputs.membench.follows = "empty-flake";
     };
     empty-flake.url = "github:input-output-hk/empty-flake?rev=2040a05b67bf9a669ce17eca56beb14b4206a99a";
-    cardano-transaction-lib.url = "github:Plutonomicon/cardano-transaction-lib?rev=1999bb962141ffea09767f299a5759420097d189";
+    cardano-transaction-lib.url = "github:Plutonomicon/cardano-transaction-lib?rev=67ae3d1a3e7128cb7f58a5b4ba365aae37133045";
     cardano-ogmios.url = "github:input-output-hk/cardano-ogmios";
     mlabs-ogmios.follows = "cardano-transaction-lib/ogmios";
     ogmios-datum-cache.follows = "cardano-transaction-lib/ogmios-datum-cache";


### PR DESCRIPTION
To solve the issue regarding non-existing revision error due to ctl history rewrite, I looked at our lockfiles timestam, when CTL was updated and searched for the respective date/time in CTLs git log to find the respective new revision hash.

other changes

- [ ] The impure tests via `nix run .#offchain:test` were run and all are passing.
- [ ] Where applicable, grammar, punctuation, and spelling within code and comments should be plausibly correct.
- [ ] The issue(s) that the work is addressing should be linked in the PR description.
- [ ] Any significant changes beyond what's clear from the linked issue(s) are documented in the PR description

